### PR TITLE
Fixes headers when there is no login/passcode

### DIFF
--- a/lib/onstomp/client.rb
+++ b/lib/onstomp/client.rb
@@ -82,11 +82,12 @@ class OnStomp::Client
     # FIXME: This is a quick fix to force the Threaded IO processor to
     # complete its work before we establish a connection.
     processor_inst.stop
-    @connection = OnStomp::Connections.connect self, headers,
-      { :'accept-version' => @versions.join(','), :host => @host,
-        :'heart-beat' => @heartbeats.join(','), :login => @login,
-        :passcode => @passcode }, pending_connection_events,
-      read_timeout, write_timeout
+    c_head = { :'accept-version' => @versions.join(','), :host => @host,
+        :'heart-beat' => @heartbeats.join(',') }
+    c_head[:login] = @login if ! @login.nil? && ! @login.empty?
+    c_head[:passcode] = @passcode if ! @passcode.nil? && ! @passcode.empty?
+    @connection = OnStomp::Connections.connect self, headers, c_head,
+      pending_connection_events, read_timeout, write_timeout
     processor_inst.start
     self
   end


### PR DESCRIPTION
In the current implementation, if the user does not define a login and
passcode, then the library sets their values to '' and the headers that
are sent to the STOMP server are the following:

```
CONNECT
accept-version:1.0,1.1
host:stomp-server.example.com
heart-beat:0,0
login:
passcode:
```

When this is tested against ActiveMQ (version 5.8.0), the connection
fails with the following error:

```
ERROR
content-type:text/plain
message:User name [] or password is invalid.
```

According to the STOMP protocol specification, the clients MAY set the
login and passcode headers. It seems that when the user does not define
a login and passcode, then the CONNECT frame must not include these
headers.

This commit changes the existing behaviour and when the user does not
define a login and a passcode, then the library does not include these
headers in the CONNECT frame.