### PR TITLE
pass options through to underlying clients

### DIFF
--- a/lib/onstomp/failover/client.rb
+++ b/lib/onstomp/failover/client.rb
@@ -45,7 +45,7 @@ class OnStomp::Failover::Client
     end
     @client_mutex = Mutex.new
     configure_configurable options
-    create_client_pool hosts
+    create_client_pool hosts, options
     @active_client = nil
     @connection = nil
     @frame_buffer = buffer.new self
@@ -129,8 +129,8 @@ class OnStomp::Failover::Client
     sleep(retry_delay) if retry_delay > 0 && attempt > 1
   end
     
-  def create_client_pool hosts
-    @client_pool = pool.new hosts
+  def create_client_pool hosts, options
+    @client_pool = pool.new hosts, options
     on_connection_closed do |client, *_|
       if client == active_client
         unless @disconnecting

--- a/lib/onstomp/failover/pools/base.rb
+++ b/lib/onstomp/failover/pools/base.rb
@@ -8,9 +8,9 @@ class OnStomp::Failover::Pools::Base
   
   # Creates a new client pool by mapping an array of URIs into an array of
   # {OnStomp::Client clients}.
-  def initialize hosts
+  def initialize hosts, options = {}
     @clients = hosts.map do |h|
-      h.is_a?(OnStomp::Client) ? h : OnStomp::Client.new(h)
+      h.is_a?(OnStomp::Client) ? h : OnStomp::Client.new(h, options)
     end
   end
   

--- a/lib/onstomp/failover/pools/round_robin.rb
+++ b/lib/onstomp/failover/pools/round_robin.rb
@@ -3,7 +3,7 @@
 # A round-robin client pool. Clients are processed sequentially, and once
 # all clients have been processed, the pool cycles back to the beginning.
 class OnStomp::Failover::Pools::RoundRobin < OnStomp::Failover::Pools::Base
-  def initialize uris
+  def initialize uris, options = {}
     super
     @index = -1
   end

--- a/spec/onstomp/failover/client_spec.rb
+++ b/spec/onstomp/failover/client_spec.rb
@@ -3,6 +3,7 @@ require 'spec_helper'
 
 module OnStomp::Failover
   describe Client, :failover => true do
+    let(:client_options) { Hash.new }
     let(:active_client) {
       mock('active client').tap do |m|
         m.extend OnStomp::Interfaces::ClientEvents
@@ -26,7 +27,16 @@ module OnStomp::Failover
         c.hosts.should == ['stomp:///', real_client]
       end
     end
-    
+
+    # doesn't work, no idea why not but 2+ hours is my time limit
+    # describe "configuration" do
+    #
+    #   it "should pass client options to the client" do
+    #     Pools::Base.should_receive(:new).with(anything(), {})
+    #     client.connect
+    #    end
+    # end
+
     describe ".connected?" do
       it "should be connected if it has an active client that's connected" do
         active_client.stub(:connected? => true)
@@ -81,7 +91,7 @@ module OnStomp::Failover
         # Get the hooks installed on our mocks
         active_client.stub(:connection => connection)
         client.stub(:client_pool => client_pool)
-        client.__send__ :create_client_pool, []
+        client.__send__ :create_client_pool, [], {}
       end
       it "should do nothing special if there is no active client" do
         client.stub(:active_client => nil)

--- a/spec/onstomp/failover/pools/base_spec.rb
+++ b/spec/onstomp/failover/pools/base_spec.rb
@@ -12,10 +12,10 @@ module OnStomp::Failover::Pools
 
     describe ".initialize" do
       it "should create a new Client for each URI" do
-        OnStomp::Client.should_receive(:new).with('1').and_return('c 1')
-        OnStomp::Client.should_receive(:new).with('2').and_return('c 2')
-        OnStomp::Client.should_receive(:new).with('3').and_return('c 3')
-        new_pool = Base.new ['1', '2', '3']
+        OnStomp::Client.should_receive(:new).with('1', { option: true }).and_return('c 1')
+        OnStomp::Client.should_receive(:new).with('2', { option: true }).and_return('c 2')
+        OnStomp::Client.should_receive(:new).with('3', { option: true }).and_return('c 3')
+        new_pool = Base.new ['1', '2', '3'], { option: true }
         new_pool.clients.should =~ ['c 1', 'c 2', 'c 3']
       end
     end


### PR DESCRIPTION
Here's a fix for #26.  
It works, but I'm an rspec novice so I couldn't get the failover client spec test working properly.