### PR TITLE
Stop checking encoding names

### DIFF
--- a/spec/onstomp/connections/serializers/stomp_1_spec.rb
+++ b/spec/onstomp/connections/serializers/stomp_1_spec.rb
@@ -12,12 +12,12 @@ module OnStomp::Connections::Serializers
       let(:frame) {
         mock('frame')
       }
-      it "should call frame_to_string and encode the result to ASCII-8BIT" do
+      it "should call frame_to_string and encode the result to binary (ASCII-8BIT)" do
         serializer.stub(:frame_to_string).with(frame).and_return('SERIALIZED FRAME')
         ser = serializer.frame_to_bytes(frame)
         ser.should == 'SERIALIZED FRAME'
         if RUBY_VERSION >= '1.9'
-          ser.encoding.name.should == 'ASCII-8BIT'
+          ser.encoding.should == Encoding::BINARY
         end
       end
     end


### PR DESCRIPTION
Comparing the names is much less efficient than
comparing the instance directly.

It may also change in the future: https://bugs.ruby-lang.org/issues/18576